### PR TITLE
added shebang for shell execution

### DIFF
--- a/installation/installation.sh
+++ b/installation/installation.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 #Copy the existing german language and rename it
 cp /usr/share/i18n/locales/de_DE /usr/share/i18n/locales/de_BY 2> /dev/null
 localedef -i de_BY -f UTF-8 de_BY.UTF-8 2> /dev/null


### PR DESCRIPTION
the installation.sh could not be executed when not using bash or sh as user shell.

For example fish said
```
Failed to execute process '/usr/share/icingaweb2/modules/bayerisch/installation/installation.sh'. Reason:
exec: Exec format error
The file '/usr/share/icingaweb2/modules/bayerisch/installation/installation.sh' is marked as an executable but could not be run by the operating system.
```